### PR TITLE
Update action name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Run Action
+      - name: Set up v
         uses: chelnak/setup-v@v0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Copy pasta job and the action name was incorrect.

This commit fixes it.